### PR TITLE
Feat: add step to allow executions only in allowed branches

### DIFF
--- a/workflow-templates/upload-python-library-artifactory-v2.yml
+++ b/workflow-templates/upload-python-library-artifactory-v2.yml
@@ -24,6 +24,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
+      ALLOWED_BRANCHES: refs/heads/develop,refs/heads/master,refs/heads/release,refs/tags/
       ARTIFACTORY_TD_PYTHON_REPOSITORY_VIRTUAL: td-pypi
       ARTIFACTORY_TD_PYTHON_REPOSITORY_LOCAL: td-pypi-local
     steps:
@@ -32,6 +33,21 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.6'
+    - name: Avoid execution of non allowed branches 
+      run: |
+        allowed=false
+        for i in $(echo ${{env.ALLOWED_BRANCHES}} | tr "," "\n")
+        do
+          # process
+          if [[ ${GITHUB_REF} == *"$i"* ]]; then
+            echo "Allowed branch ${GITHUB_REF}"
+            allowed=true
+          fi  
+        done
+        if [[ $allowed == false ]]; then
+          echo "::error::Branch ${GITHUB_REF} not allowed"
+          exit 1
+        fi
     - name: Setting GitHub User
       run: |
         git config --global user.email "devops@cepsa.com"


### PR DESCRIPTION
Tested in https://github.com/cepsadigital/devops-test-artifactory-python-package-concrete-branches

En este ejemplo los branches permitidos están definidos en la variable de entorno ALLOWED_BRANCHES, lo ideal sería que estuvieran definidos en alguna propiedad a nivel organización, aunque no conozco manera de definirlo por ahora más allá de los secrets, se te ocurre alguna otra manera?